### PR TITLE
Add entrypoint code and charm structure doc

### DIFF
--- a/doc/charm-structure.rst
+++ b/doc/charm-structure.rst
@@ -1,0 +1,67 @@
+Charm Directory and File Structure
+==================================
+
+A typical charm would have the following parts:
+
+* ``config.yaml`` and ``metadata.yaml``;
+* ``hooks`` directory with **symlinks corresponding to event names**. The
+  symlinks point to a file to a python file ``run_main.py`` that:
+  * extends python module search path to include the ``lib`` directory;
+  * calls an entrypoint function from ``entrypoint.py``;
+* ``lib/juju/framework.py`` - contains the charm framework code;
+* ``lib/juju/entrypoint.py`` contains the code needed to:
+  * **initialize** the charm framework for a given hook invocation;
+  * **create** the **in-memory state** of the charm
+    * in-memory state includes observers, emitters, persisted local state
+      (handled by the framework) and Juju model state snapshot parts they care
+      about (the **world view**);
+    * a module-level ``Charm`` class definition from ``lib/charm.py`` provided
+      by a charm author is used.
+  * **re-emit** any **deferred** events;
+  * **emit** the **new** Juju-originating event for the current hook invocation;
+  * **commit** (persist) the framework state.
+* ``lib/juju/charm.py`` - contains a base class for other charm class
+  implementations;
+* ``lib/charm.py`` - contains a concrete implementation of a charm;
+  * the charm class can have any name;
+  * a module-level ``Charm = YourClassName`` variable needs to be present for
+  * ``entrypoint.py`` code to work;
+* ``lib/mysql_requires_endpoint.py`` - contains an endpoint class
+  implementation which handles events specific to a given endpoint from
+  ``metadata.yaml``;
+  * modules like this can be placed under ``lib`` or child directories in as a
+    developer sees fit.
+
+Example
+-------
+
+.. code-block:: bash
+
+    charms/mysql/
+    ├── config.yaml
+    ├── hooks
+    │   ├── config-changed -> run_main.py
+    │   ├── install -> run_main.py
+    │   ├── leader-elected -> run_main.py
+    │   ├── leader-settings-changed -> run_main.py
+    │   ├── run_main.py
+    │   ├── mysql-relation-broken -> run_main.py
+    │   ├── mysql-relation-changed -> run_main.py
+    │   ├── mysql-relation-departed -> run_main.py
+    │   ├── mysql-relation-joined -> run_main.py
+    │   ├── post-series-upgrade -> run_main.py
+    │   ├── pre-series-upgrade -> run_main.py
+    │   ├── start -> run_main.py
+    │   ├── stop -> run_main.py
+    │   ├── update-status -> run_main.py
+    │   └── upgrade-charm -> run_main.py
+    ├── lib
+    │   ├── charm.py
+    │   ├── __init__.py
+    │   ├── juju
+    │   │   ├── charm.py
+    │   │   ├── entrypoint.py
+    │   │   ├── framework.py
+    │   │   └── __init__.py
+    │   └── mysql_requires_endpoint.py
+    └── metadata.yaml

--- a/juju/entrypoint.py
+++ b/juju/entrypoint.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+# use modules from the lib directory - works under an assumption that
+# the current directory is the top-level charm directory ($JUJU_CHARM_DIR)
+sys.path.append('lib')
+
+from juju.framework import Framework # noqa
+from charm import Charm # noqa
+
+
+try:
+    from charmhelpers.core.hookenv import log
+except (ImportError, ModuleNotFoundError):
+    log = print
+
+
+def get_juju_event_name():
+    """Get an event name that caused a hook execution to happen.
+
+    JUJU_HOOK_NAME or JUJU_ACTION_NAME are not used to support simulation of
+    events from debugging sessions
+
+    :return: an event name that caused a hook execution to happen
+    :rtype: str
+    """
+    return os.path.basename(sys.argv[0])
+
+
+def format_event_name(juju_event_name):
+    """Formats a juju event name for use in Python
+
+    :param str event_name: A Juju event name to format (e.g. config-changed)
+    :return: A formatted event name (e.g. config_changed)
+    :rtype: str
+    """
+    return juju_event_name.replace('-', '_')
+
+
+def emit_charm_event(charm, event_name):
+    """Emits a charm event based on a Juju event name
+
+    :param charm: A charm instance to emit an event from
+    :type charm: py:class:`juju.charm.Charm`
+    :param str event_name: A Juju event name to emit on a charm
+    """
+    formatted_event_name = format_event_name(event_name)
+    try:
+        event_to_emit = getattr(charm.on, formatted_event_name)
+    except AttributeError as e:
+        msg = f"Event {formatted_event_name} not defined for {charm}"
+        raise NotImplementedError(msg) from e
+
+    log(
+        f'Emitting a charm event based on a Juju event {event_to_emit},'
+        f' event type {event_to_emit.event_type},'
+        f' event kind {event_to_emit.event_kind}'
+    )
+    event_to_emit.emit()
+
+
+def setup_memory_state(framework):
+    """Sets up in-memory state (object hierarchy and observation etc.)
+
+    It is likely that in most cases the hierarchy will be as follows:
+
+    framework -> charm object -> member child objects (endpoints, components)
+
+    In other words: there is a single charm object under the framework object
+    with many child objects under the charm object.
+
+    The charm class should hold all necessary setup code for the modeled
+    application such as object instantiation, setup of observation of events
+    (which may also be done in child classes).
+
+    :param framework: A charm instance to emit an event from
+    :type framework: py:class:`juju.framework.Framework`
+
+    :return: The top-level charm object which is ready to process new Juju
+             events from the current hook execution.
+    :rtype: py:class:`juju.charm.Charm`
+    """
+    return Charm(framework)
+
+
+def entrypoint():
+    """An entry point for a charm.
+    """
+
+    # reuse the same db file as used by charm-helpers
+    # TODO: if Juju uniter agent crashes after exit(0) from the charm code
+    # the framework will commit the snapshot but Juju will not commit its
+    # operation
+    db_path = os.path.join(
+        os.environ.get('CHARM_DIR', ''), '.unit-state.db')
+
+    framework = Framework(data_path=db_path)
+
+    charm = setup_memory_state(framework)
+
+    framework.reemit()
+
+    # process the Juju event relevant to the current hook execution
+    juju_event_name = get_juju_event_name()
+    emit_charm_event(charm, juju_event_name)
+
+    framework.commit()
+    framework.close()

--- a/juju/run_main.py
+++ b/juju/run_main.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import sys
+
+# use modules from the lib directory - works under an assumption that
+# the current directory is the top-level charm directory ($JUJU_CHARM_DIR)
+sys.path.append('lib')
+
+from juju.entrypoint import entrypoint # noqa
+
+if __name__ == '__main__':
+    entrypoint()

--- a/test/charm.py
+++ b/test/charm.py
@@ -1,0 +1,3 @@
+class Charm:
+    def __init__(self, framework):
+        pass

--- a/test/test_entrypoint.py
+++ b/test/test_entrypoint.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python3
+
+import unittest
+
+import juju.entrypoint as ep
+
+import charm
+
+from unittest.mock import patch
+
+
+class TestEntrypoint(unittest.TestCase):
+
+    def setUp(self):
+        self.event_name = 'config-changed'
+        argv_patch = patch('sys.argv', [self.event_name])
+        argv_patch.start()
+        self.addCleanup(argv_patch.stop)
+
+    def tearDown(self):
+        pass
+
+    @patch('juju.entrypoint.emit_charm_event')
+    @patch('juju.entrypoint.get_juju_event_name')
+    @patch('juju.entrypoint.setup_memory_state')
+    @patch('juju.entrypoint.Framework')
+    def test_entrypoint(self, _Framework, _setup_memory_state,
+                        _get_juju_event_name, _emit_charm_event):
+        _get_juju_event_name.return_value = self.event_name
+
+        charm_instance = _setup_memory_state.return_value
+        framework_instance = _Framework.return_value
+
+        ep.entrypoint()
+
+        _setup_memory_state.assert_called_once_with(framework_instance)
+        framework_instance.reemit.assert_called_once()
+        _get_juju_event_name.assert_called_once_with()
+        _emit_charm_event.assert_called_once_with(charm_instance,
+                                                  self.event_name)
+
+        framework_instance.commit.assert_called_once()
+        framework_instance.close.assert_called_once()
+
+    @patch('juju.entrypoint.Charm')
+    @patch('juju.entrypoint.Framework')
+    def test_setup_memory_state(self, _Framework, _Charm):
+        charm_instance = _Charm.return_value
+        framework_instance = _Framework.return_value
+
+        self.assertEqual(ep.setup_memory_state(framework_instance),
+                         charm_instance)
+
+    @patch('juju.entrypoint.Charm')
+    @patch('juju.entrypoint.Framework')
+    def test_emit_charm_event_has_handler(self, _Framework, _Charm):
+        framework_instance = _Framework.return_value
+
+        charm_instance = ep.setup_memory_state(framework_instance)
+
+        event = getattr(charm_instance.on, self.event_name.replace('-', '_'))
+
+        ep.emit_charm_event(charm_instance, self.event_name)
+
+        event.emit.assert_called_once()
+
+    @patch('juju.entrypoint.Charm')
+    @patch('juju.entrypoint.Framework')
+    def test_emit_charm_event_no_handler(self, _Framework, _Charm):
+        framework_instance = _Framework.return_value
+
+        charm_instance = charm.Charm(framework_instance)
+
+        self.assertRaises(NotImplementedError, ep.emit_charm_event,
+                          charm_instance, self.event_name)
+
+    def test_get_juju_event_name(self):
+        self.assertEqual(ep.get_juju_event_name(), self.event_name)
+
+    def test_format_event_name(self):
+        self.assertEqual(ep.format_event_name('start'),
+                         'start')
+        self.assertEqual(ep.format_event_name('config-changed'),
+                         'config_changed')
+        self.assertEqual(ep.format_event_name('leader-settings-changed'),
+                         'leader_settings_changed')
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds entrypoint code which will be used by charm implementations in
order to initialize the framework and other in-memory state and dispatch
a new Juju event. Additionally, the expected charm file and directory
structure is documented.