### PR TITLE
Add entrypoint code

### DIFF
--- a/juju/charm.py
+++ b/juju/charm.py
@@ -13,7 +13,7 @@ class LeaderElected(EventBase): pass
 class LeaderSettingsChanged(EventBase): pass
 
 
-class CharmEvents(EventsBase):
+class CharmEventsBase(EventsBase):
 
     install = Event(InstallEvent)
     start = Event(StartEvent)
@@ -27,6 +27,6 @@ class CharmEvents(EventsBase):
     leader_settings_changed = Event(LeaderSettingsChanged)
 
 
-class Charm(Object):
+class CharmBase(Object):
 
-    on = CharmEvents()
+    on = CharmEventsBase()

--- a/juju/entrypoint.py
+++ b/juju/entrypoint.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import yaml
+
+import juju.framework
+
+from juju.framework import (
+    Framework,
+    Event,
+    BoundEvent
+)
+from charm import Charm
+
+# Reuse the same db file as used by charm-helpers.
+DB_PATH = os.path.join(
+    os.environ.get('CHARM_DIR', ''), '.unit-state.db')
+
+try:
+    from charmhelpers.core.hookenv import log
+except (ImportError, ModuleNotFoundError):
+    log = print
+
+
+def load_metadata():
+    with open('metadata.yaml') as f:
+        metadata = yaml.load(f)
+    return metadata
+
+
+def get_charm_endpoints():
+    """Get a list of endpoints from the charm metadata.
+    """
+    metadata = load_metadata()
+    charm_endpoints = list()
+    for endpoint_type in ['provides', 'requires', 'peers']:
+        endpoints = metadata.get(endpoint_type)
+        if endpoints:
+            charm_endpoints.extend(endpoints)
+    return charm_endpoints
+
+
+def setup_hooks():
+    """Set up hooks for supported events.
+
+    Whether a charm can handle an event or not can be determined by
+    introspecting which events are bound to it.
+    """
+
+    relation_events = list()
+    for endpoint in get_charm_endpoints():
+        relation_events.extend([
+            f'{endpoint}_relation_{t}'
+            for t in ['joined', 'changed', 'departed', 'broken']
+        ])
+
+    log(f'Discovered relation events from charm metadata: {relation_events}')
+
+    # Get core event names that CharmBase knows about
+    core_events = [event_name for event_name, instance
+                   in juju.charm.CharmEventsBase.__dict__.items()
+                   if type(instance) == Event]
+
+    log(f'Discovered core charm events: {core_events}')
+
+    # Discover Juju events supported by the charm using reflection.
+    supported_juju_events = [
+        event_name for event_name in dir(Charm.on)
+        if (type(getattr(Charm.on, event_name)) == BoundEvent
+            and (event_name in relation_events or event_name in core_events))
+    ]
+    log('Discovered Juju events supported by the charm by'
+        f' introspecting it: {supported_juju_events}')
+
+    # Create symlinks to "install" which may be either a copy of main.py
+    # (which calls the entrypoint function) or a symlink to it. Note
+    # that it is important to avoid creating a recursive symlink.
+    supported_juju_events.remove('install')
+
+    for event_name in supported_juju_events:
+        event_hook_path = f'hooks/{event_name.replace("_", "-")}'
+        if os.path.exists(event_hook_path):
+            log(f'Removing an old symlink named {event_hook_path}')
+            os.unlink(event_hook_path)
+        log(f'Creating a new symlink named {event_hook_path} to hooks/install')
+        os.symlink('install', event_hook_path)
+
+
+def emit_charm_event(charm, event_name):
+    """Emits a charm event based on a Juju event name.
+
+    charm -- A charm instance to emit an event from.
+    event_name -- A Juju event name to emit on a charm.
+    """
+    formatted_event_name = event_name.replace('-', '_')
+    try:
+        event_to_emit = getattr(charm.on, formatted_event_name)
+    except AttributeError as e:
+        msg = f"event {formatted_event_name} not defined for {charm}"
+        raise NotImplementedError(msg) from e
+
+    log(f'Emitting Juju event {event_name}')
+    event_to_emit.emit()
+
+
+def entrypoint():
+    """An entry point for a charm.
+
+    Sets up in-memory state (object hierarchy and observation etc.).
+
+    The expected hierarchy is a single charm object under the framework
+    object with many child objects under the charm object:
+
+    framework -> charm object -> member child objects (endpoints, components)
+
+    The charm class should hold all necessary setup code for the modeled
+    application such as object instantiation, setup of observation of events
+    (which may also be done in child classes).
+
+    """
+
+    # TODO: If Juju unit agent crashes after exit(0) from the charm code
+    # the framework will commit the snapshot but Juju will not commit its
+    # operation.
+    framework = None
+    try:
+        framework = Framework(data_path=DB_PATH)
+
+        # Set up charm-specific in-memory state.
+        charm = Charm(framework, 0)
+
+        framework.reemit()
+
+        juju_event_name = os.path.basename(sys.argv[0])
+
+        # Set up hooks on initial install or charm upgrade. Note that if
+        # a charm is force-upgraded this will only be called after
+        # upgrade-charm is executed.
+        if juju_event_name in ['install', 'upgrade-charm']:
+            setup_hooks()
+
+        # Process the Juju event relevant to the current hook execution
+        # JUJU_HOOK_NAME or JUJU_ACTION_NAME are not used to support simulation
+        # of events from debugging sessions.
+        emit_charm_event(charm, juju_event_name)
+
+        framework.commit()
+    finally:
+        if framework:
+            framework.close()

--- a/juju/main.py
+++ b/juju/main.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+
+# Use modules from the $JUJU_CHARM_DIR/lib directory. An absolute path
+# is used as using a symlink like hooks/install -> ../lib/juju/main.py
+# will result in $JUJU_CHARM_DIR/lib/juju being the first path stored
+# in sys.path during hook execution which is undesirable.
+# This happens because the directory containing a script is added to
+# sys.path by the interpreter which gets resolved if it is a symlink.
+del sys.path[0]
+sys.path.insert(0, os.path.join(os.environ.get("JUJU_CHARM_DIR", ''), 'lib'))
+
+from juju.entrypoint import entrypoint # noqa
+
+if __name__ == '__main__':
+    entrypoint()

--- a/test/test_entrypoint.py
+++ b/test/test_entrypoint.py
@@ -1,0 +1,300 @@
+#!/usr/bin/python3
+
+import unittest
+import logging
+import inspect
+import tempfile
+import os
+import sys
+import shutil
+import types
+import yaml
+
+import juju.charm
+from juju.framework import (
+    Event,
+    BoundEvent,
+)
+
+from unittest.mock import (
+    patch,
+    call,
+)
+
+from pathlib import Path
+
+
+logger = logging.getLogger()
+logger.level = logging.DEBUG
+stream_handler = logging.StreamHandler(sys.stdout)
+logger.addHandler(stream_handler)
+
+
+def import_code(code, module_name):
+    """Dynamically import code into a module with a given name.
+    """
+    dynamic_module = types.ModuleType(module_name)
+    # Execute the provided code in the context of the
+    # file-less module created dynamically in memory
+    exec(code, dynamic_module.__dict__)
+    sys.modules[module_name] = dynamic_module
+
+
+# Import a dynamic module called "charm" with a Charm class stub
+import_code('''
+import juju.charm
+class Charm(juju.charm.CharmBase): pass
+''', 'charm')
+
+# Import entrypoint code after the module called "charm" becomes importable
+import juju.entrypoint as ep # noqa
+
+
+def get_charm_event_names(charm_type):
+    """Gets event names for a given charm class.
+
+    charm_type - a charm class to get events for.
+    """
+    return [
+        event_name for event_name
+        in dir(charm_type.on)
+        if type(getattr(charm_type.on, event_name)) == BoundEvent
+    ]
+
+
+class TestEntrypoint(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp())
+        db_path_patch = patch('juju.entrypoint.DB_PATH',
+                              os.path.join(self.tmpdir, '.unit-state.db'))
+        db_path_patch.start()
+        self.addCleanup(db_path_patch.stop)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_event_reemitted(self):
+        # note: class variables are modified because Charm instances
+        # are not preserved across simulated hook executions
+        class CharmConfigDeferrer(juju.charm.CharmBase):
+            defer = True
+            count_called = 0
+            count_deferred = 0
+
+            def __init__(self, framework, key):
+                super().__init__(framework, key)
+                self.framework.observe(self.on.config_changed, self)
+
+            def on_config_changed(self, event):
+                logger.debug(f'In {inspect.stack()[0].function}')
+                if self.defer:
+                    event.defer()
+                    type(self).defer = False
+                    type(self).count_deferred += 1
+                type(self).count_called += 1
+
+        with patch('juju.entrypoint.Charm', CharmConfigDeferrer):
+            with patch('sys.argv', ['config-changed']):
+                ep.entrypoint()
+                self.assertEqual(CharmConfigDeferrer.count_called, 1)
+                self.assertEqual(CharmConfigDeferrer.defer, False)
+
+            # update-status does not have a handler but config-changed
+            # should be handled because it was previously deferred
+            with patch('sys.argv', ['update-status']):
+                patch_update_status = patch('sys.argv', ['update-status'])
+                patch_update_status.start()
+
+                ep.entrypoint()
+                # re-emit should pick the deferred config-changed
+                self.assertEqual(CharmConfigDeferrer.count_called, 2)
+                self.assertEqual(CharmConfigDeferrer.defer, False)
+
+    @patch('juju.entrypoint.setup_hooks')
+    def test_all_base_events_handled(self, _setup_hooks):
+        # note: class variables are modified because Charm instances
+        # are not preserved across simulated hook executions
+        class Charm(juju.charm.CharmBase):
+            count_called = 0
+
+            events_to_observe = []
+            events_types_observed = set()
+
+            on = juju.charm.CharmEventsBase()
+
+            def __init__(self, framework, key):
+                super().__init__(framework, key)
+                for event_name in self.events_to_observe:
+                    self.framework.observe(getattr(self.on, event_name), self)
+
+            def _handler_core(self, event):
+                logger.debug(f'In {inspect.stack()[0].function},'
+                             f' event {event}')
+                type(self).count_called += 1
+                type(self).events_types_observed.add(type(event))
+
+        # infer supported "base" events from the base charm class
+        base_events = {event_name: instance for event_name, instance
+                       in juju.charm.CharmEventsBase.__dict__.items()
+                       if type(instance) == juju.framework.Event}
+
+        event_names = base_events.keys()
+        event_types = {e.event_type for e in base_events.values()}
+
+        logger.debug(f'Expected event types {event_types}')
+
+        # make sure all of the base events are observed
+        Charm.events_to_observe = event_names
+
+        # set up handlers for all base events reusing one implementation
+        for event_name in event_names:
+            setattr(Charm, f'on_{event_name}', Charm._handler_core)
+
+        # simulate hook executions for every event
+        for event_name in event_names:
+            with patch('sys.argv', [event_name]):
+                with patch('juju.entrypoint.Charm', Charm):
+                    ep.entrypoint()
+
+        logger.debug(f'Events types observed {Charm.events_types_observed}')
+
+        self.assertEqual(len(event_names), Charm.count_called)
+        self.assertEqual(Charm.events_types_observed, event_types)
+
+    def test_event_not_implemented(self):
+        """Make sure Juju events are not silently skipped.
+        """
+        class Charm(juju.charm.CharmBase):
+            on = juju.charm.CharmEventsBase()
+
+        with patch('juju.entrypoint.Charm', Charm):
+            with patch('sys.argv', ['not-implemented-event']):
+                self.assertRaises(NotImplementedError, ep.entrypoint)
+
+    @patch('juju.entrypoint.load_metadata')
+    @patch('os.path.exists')
+    @patch('os.unlink')
+    @patch('os.symlink')
+    def test_setup_hooks(self, _os_symlink, _os_unlink,
+                         _os_path_exists, _load_metadata):
+        _load_metadata.return_value = yaml.load(
+            '''
+            provides:
+              db:
+                interface: db
+            requires:
+              mon:
+                interface: monitoring
+            peers:
+              ha:
+                interface: cluster
+            '''
+        )
+
+        class DBRelationJoined(juju.framework.EventBase):
+            pass
+
+        class DBRelationChanged(juju.framework.EventBase):
+            pass
+
+        class DBRelationDeparted(juju.framework.EventBase):
+            pass
+
+        class DBRelationBroken(juju.framework.EventBase):
+            pass
+
+        class MonRelationJoined(juju.framework.EventBase):
+            pass
+
+        class MonRelationChanged(juju.framework.EventBase):
+            pass
+
+        class MonRelationDeparted(juju.framework.EventBase):
+            pass
+
+        class MonRelationBroken(juju.framework.EventBase):
+            pass
+
+        class HARelationJoined(juju.framework.EventBase):
+            pass
+
+        class HARelationChanged(juju.framework.EventBase):
+            pass
+
+        class HARelationDeparted(juju.framework.EventBase):
+            pass
+
+        class HARelationBroken(juju.framework.EventBase):
+            pass
+
+        class CharmEvents(juju.charm.CharmEventsBase):
+            db_relation_joined = Event(DBRelationJoined)
+            db_relation_changed = Event(DBRelationChanged)
+            db_relation_departed = Event(DBRelationDeparted)
+            db_relation_broken = Event(DBRelationBroken)
+            mon_relation_joined = Event(MonRelationJoined)
+            mon_relation_changed = Event(MonRelationChanged)
+            mon_relation_departed = Event(MonRelationDeparted)
+            mon_relation_broken = Event(MonRelationBroken)
+            ha_relation_joined = Event(HARelationJoined)
+            ha_relation_changed = Event(HARelationChanged)
+            ha_relation_departed = Event(HARelationDeparted)
+            ha_relation_broken = Event(HARelationBroken)
+
+        class Charm(juju.charm.CharmBase):
+            on = CharmEvents()
+
+        event_hooks = [f'hooks/{e.replace("_", "-")}'
+                       for e in get_charm_event_names(Charm)
+                       if e != 'install']
+
+        def assess_setup_hooks(event_name, assume_path_exists):
+            with patch('juju.entrypoint.Charm', Charm):
+                with patch('sys.argv', [event_name]):
+                    ep.setup_hooks()
+                    _os_symlink.assert_has_calls(
+                        [call('install', event_hook)
+                         for event_hook in event_hooks],
+                        any_order=True)
+
+                    if _os_path_exists.return_value:
+                        _os_unlink.assert_has_calls(
+                            [call(event_hook)
+                             for event_hook in event_hooks])
+
+                    # avoid attempting to create
+                    # a symlink pointing to itself
+                    tried_recursion = None
+                    try:
+                        _os_symlink.assert_has_calls([
+                            call('install', 'hooks/install')])
+                        tried_recursion = True
+                    except AssertionError:
+                        tried_recursion = False
+
+                    self.assertFalse(tried_recursion)
+
+        for event_name in ['install', 'upgrade-charm']:
+            _os_symlink.reset_mock()
+            _os_path_exists.reset_mock()
+            _os_path_exists.return_value = False
+            _os_unlink.reset_mock()
+
+            assess_setup_hooks(
+                event_name,
+                assume_path_exists=_os_path_exists.return_value)
+
+        for event_name in ['install', 'upgrade-charm']:
+            _os_symlink.reset_mock()
+            _os_path_exists.reset_mock()
+            _os_unlink.reset_mock()
+            _os_path_exists.return_value = True
+            assess_setup_hooks(
+                event_name,
+                assume_path_exists=_os_path_exists.return_value
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds entrypoint code which will be used by charm implementations in
order to initialize the framework and other in-memory state and dispatch
a new Juju event. Additionally, the expected charm file and directory
structure is documented.